### PR TITLE
aws: do not timeout if there is a violation, instead just return an

### DIFF
--- a/builtin/providers/aws/conversions.go
+++ b/builtin/providers/aws/conversions.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/awslabs/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"

--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -130,8 +130,6 @@ func resourceAwsInternetGatewayDelete(d *schema.ResourceData, meta interface{}) 
 		switch ec2err.Code() {
 		case "InvalidInternetGatewayID.NotFound":
 			return nil
-		case "DependencyViolation":
-			return err // retry
 		}
 
 		return resource.RetryError{Err: err}
@@ -234,10 +232,11 @@ func detachIGStateRefreshFunc(conn *ec2.EC2, instanceID, vpcID string) resource.
 					return nil, "Not Found", err
 				} else if ec2err.Code() == "Gateway.NotAttached" {
 					return "detached", "detached", nil
-				} else if ec2err.Code() == "DependencyViolation" {
-					return nil, "detaching", nil
 				}
 			}
+
+			log.Printf("[ERROR] on detachIGStateRefreshFunc: %#v", err)
+			return nil, "", err
 		}
 		// DetachInternetGateway only returns an error, so if it's nil, assume we're
 		// detached

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -326,9 +326,6 @@ func resourceAwsSecurityGroupDelete(d *schema.ResourceData, meta interface{}) er
 			switch ec2err.Code() {
 			case "InvalidGroup.NotFound":
 				return nil
-			case "DependencyViolation":
-				// If it is a dependency violation, we want to retry
-				return err
 			default:
 				// Any other error, we want to quit the retry loop immediately
 				return resource.RetryError{Err: err}

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -174,12 +174,6 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 			_, err := conn.DeleteSubnet(req)
 			if err != nil {
 				if apiErr, ok := err.(awserr.Error); ok {
-					if apiErr.Code() == "DependencyViolation" {
-						// There is some pending operation, so just retry
-						// in a bit.
-						return 42, "pending", nil
-					}
-
 					if apiErr.Code() == "InvalidSubnetID.NotFound" {
 						return 42, "destroyed", nil
 					}


### PR DESCRIPTION
This is a false positive and causes us too timeout when we are calling
destroy on a tf file, which is used by instances outside the terraform
state file.  In that case, because the instances can't be created
anymore, Terraform doesn't return an error in the case of a
DependencyViolation, instead it's tries to delete it over and over
again, until it times out.

We want eventually that it returns immediately, so we know what the
underlying problem is. Right now it's being hided.

Related issue: https://github.com/hashicorp/terraform/pull/1368#issuecomment-147357768
